### PR TITLE
Adds a style module for Predix colors

### DIFF
--- a/colors-shared-styles.html
+++ b/colors-shared-styles.html
@@ -1,0 +1,122 @@
+<!--
+  Shared styles module for using predix colors inside of mixins and css properties.
+  E.g.,
+    background-color: var(--px-blue, --default-primary-color);
+
+  To refer inside your element, use `<style include="../path/to/module/px-colors-design/colors-shared-styles.html">`
+-->
+<dom-module id="colors-shared-styles">
+  <template>
+    <style>
+    /**
+     * Exposes common Predix colors as CSS variables.
+     */
+    :root {
+      /**
+       * Brand Colors
+       */
+      /**
+       * Primary
+       */
+      --px-red: rgb(227,37,51);
+      --px-blue: rgb(0,92,185);
+      --px-green: rgb(70,173,0);
+      --px-purple: rgb(134,105,255);
+      --px-orange: rgb(255,152,33);
+      --px-yellow: rgb(255,237,69);
+      /**
+       * Light
+       */
+      --px-red-light: rgb(255,92,92);
+      --px-blue-light: rgb(54,147,248);
+      --px-green-light: rgb(117,216,53);
+      --px-purple-light: rgb(156,151,255);
+      --px-orange-light: rgb(255,187,102);
+      --px-yellow-light: rgb(255,249,141);
+      /**
+       * Dark
+       */
+      --px-red-dark: rgb(182,18,37);
+      --px-blue-dark: rgb(0,54,110);
+      --px-green-dark: rgb(29,95,17);
+      --px-purple-dark: rgb(89,81,148);
+      --px-orange-dark: rgb(229,92,0);
+      --px-yellow-dark: rgb(255,207,69);
+      /**
+       * Monochromatic (gray10 is darkest, gray1 is lightest)
+       */
+      --px-black: rgb(0,0,0);
+      --px-gray10: rgb(36,35,38);
+      --px-gray9: rgb(59,59,63);
+      --px-gray8: rgb(82,81,86);
+      --px-gray7: rgb(124,124,132);
+      --px-gray6: rgb(153,153,163);
+      --px-gray5: rgb(177,177,188);
+      --px-gray4: rgb(209,208,216);
+      --px-gray3: rgb(228,228,234);
+      --px-gray2: rgb(239,239,244);
+      --px-gray1: rgb(247,247,252);
+      --px-white: rgb(255,255,255);
+      --px-graybg: rgb(139,141,143);
+      /**
+       * Buttons
+       */
+      --px-primary-blue: rgb(62,135,232);
+      --px-primary-blue-hover: rgb(53,115,197);
+      --px-primary-blue-pressed: rgb(43,94,162);
+      /**
+       * Selection
+       */
+      --px-select-blue-default: rgb(10,158,193);
+      --px-select-blue-hover: rgb(9,134,164);
+      --px-select-blue-pressed: rgb(8,110,135);
+      /**
+       * Alerts
+       */
+      --px-alert-red: rgb(229,56,56);
+      --px-alert-orange: rgb(221,107,31);
+      --px-alert-yellow: rgb(232,167,54);
+      --px-alert-blue: rgb(67,100,221);
+      /**
+       * Data Visualization
+       */
+      /**
+       * Basic
+       */
+      --px-dv-basic-gray: rgb(77,77,77);
+      --px-dv-basic-blue: rgb(93,165,218);
+      --px-dv-basic-orange: rgb(250,164,58);
+      --px-dv-basic-green: rgb(96,189,104);
+      --px-dv-basic-pink: rgb(241,124,176);
+      --px-dv-basic-brown: rgb(178,145,47);
+      --px-dv-basic-purple: rgb(178,118,178);
+      --px-dv-basic-yellow: rgb(222,207,63);
+      --px-dv-basic-red: rgb(241,88,84);
+      /**
+       * Light
+       */
+      --px-dv-light-gray: rgb(140,140,140);
+      --px-dv-light-blue: rgb(136,189,230);
+      --px-dv-light-orange: rgb(251,178,88);
+      --px-dv-light-green: rgb(144,205,151);
+      --px-dv-light-pink: rgb(246,170,201);
+      --px-dv-light-brown: rgb(191,165,84);
+      --px-dv-light-purple: rgb(188,153,199);
+      --px-dv-light-yellow: rgb(237,221,70);
+      --px-dv-light-red: rgb(240,126,110);
+      /**
+       * Dark
+       */
+      --px-dv-dark-gray: var(--px-black);
+      --px-dv-dark-blue: rgb(38,93,171);
+      --px-dv-dark-orange: rgb(223,92,36);
+      --px-dv-dark-green: rgb(5,151,72);
+      --px-dv-dark-pink: rgb(229,18,111);
+      --px-dv-dark-brown: rgb(157,114,42);
+      --px-dv-dark-purple: rgb(123,58,150);
+      --px-dv-dark-yellow: rgb(199,180,46);
+      --px-dv-dark-red: rgb(203,32,39);
+    }
+    </style>
+  </template>
+</dom-module>


### PR DESCRIPTION
In accordance to the docs on [style modules](https://www.polymer-project.org/1.0/docs/devguide/styling#style-modules).

This would be used for elements that want to use Predix colors without having to compile CSS.

An example of this would be when referring to a variable within a Polymer mixin e.g.,:

``` css
:host {
  my-element-mixin: {
    background-color: var(--px-blue, --default-primary-color);
  };
}
```
